### PR TITLE
RAC-6604 Fix the bug of gradle can't build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ buildscript {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.15"
         classpath(group: 'com.netflix.nebula', name: 'gradle-ospackage-plugin', version: '4.4.0' )
-        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.5"
+        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.1"
         classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1"
         //classpath 'com.netflix.nebula:gradle-lint-plugin:latest.release'
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'


### PR DESCRIPTION
**Background**
It's found that all the smi-service-xxx repo can't be built with gradle. From the error log, the old version of sonarqube cannot work. So, the version of sonarqube needs to be upgraded.

**Reviewers**
@nortonluo @AlaricChan @lanchongyizu