### PR TITLE
RAC-6592: Fix the bug of gradle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ bin/bootstrap.yml
 bin/
 build/
 src/docs/asciidoc/generated/
-src/main/resources/buildInfo.properties


### PR DESCRIPTION
**Background**
To fix the bug of gradle build, the "-src/main/resources/buildInfo.properties" needs to be removed from .gitignore.

**Reviewers**
@lanchongyizu @alaricchan